### PR TITLE
Remove explicit TYPO3 version form composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
   },
   "require": {
     "php": ">=5.5.0",
-    "typo3/cms-core": "~6.2.0||~7.6.0||~8.1.0||dev-master",
-    "typo3/cms": "^7.6.0"
+    "typo3/cms-core": "~6.2.0||~7.6.0||~8.1.0||dev-master"
   },
   "type": "typo3-cms-extension",
   "keywords": [


### PR DESCRIPTION
It's currently impossible to install the extension via composer with a TYPO3 8 version as a requirement for TYPO3 7.6 is defined in the composer.json. This requirement has been removed.