### PR TITLE
Return FileReference object from getViewHelperImage

### DIFF
--- a/Classes/Service/FocusCropService.php
+++ b/Classes/Service/FocusCropService.php
@@ -52,9 +52,6 @@ class FocusCropService extends AbstractService
         if ($image instanceof FileReference) {
             return $image->getOriginalResource();
         }
-        if ($image instanceof CoreFileReference) {
-            return $image->getOriginalFile();
-        }
         if (!MathUtility::canBeInterpretedAsInteger($src)) {
             return $resourceFactory->retrieveFileOrFolderObject($src);
         }

--- a/Classes/Service/FocusCropService.php
+++ b/Classes/Service/FocusCropService.php
@@ -50,7 +50,7 @@ class FocusCropService extends AbstractService
     {
         $resourceFactory = ResourceFactory::getInstance();
         if ($image instanceof FileReference) {
-            $image = $image->getOriginalResource();
+            return $image->getOriginalResource();
         }
         if ($image instanceof CoreFileReference) {
             return $image->getOriginalFile();


### PR DESCRIPTION
If we use the same image with different focus point settings twice we
lose the settings for the first one. This is because the
getViewHelperImage method does not return the FileReference but the
originalFile object.

I don't know why this is the case but my guess would be that it is an
error? We can however return the FileReference object instead of the
File object because they both implement the FileInterface.

Please have a look at the changes, thank you!

Fixes lochmueller/focuspoint#29