### PR TITLE
[BUGFIX] Remove class argument from fluid FlashMesage view helper

### DIFF
--- a/Resources/Private/Templates/Wizard/Focuspoint.html
+++ b/Resources/Private/Templates/Wizard/Focuspoint.html
@@ -36,7 +36,7 @@
 
 		<div id="typo3-docbody">
 			<div id="typo3-inner-docbody">
-				<f:flashMessages class="tx-extbase-flash-message"/>
+				<f:flashMessages />
 				<f:render section="content"
 									arguments="{filePath: filePath, currentTop:currentTop, currentLeft: currentLeft}"/>
 			</div>


### PR DESCRIPTION
In TYPO3 CMS 8 LTS this view helper does not have this argument
any more.