### PR TITLE
[BUGFIX] If image is type of FileReference simply return it

### DIFF
--- a/Classes/Service/FocusCropService.php
+++ b/Classes/Service/FocusCropService.php
@@ -54,6 +54,9 @@ class FocusCropService extends AbstractService
     public function getViewHelperImage($src, $image, $treatIdAsReference)
     {
         $resourceFactory = ResourceFactory::getInstance();
+        if ($image instanceof \TYPO3\CMS\Core\Resource\FileReference) {
+            return $image;
+        }
         if ($image instanceof FileReference) {
             return $image->getOriginalResource();
         }


### PR DESCRIPTION
Hi, if a FileReference is given, just return it. 