### PR TITLE
When using realCrop in ImageViewHelper a new src-argument is built bu…

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -40,8 +40,8 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
         try {
             $internalImage = $service->getViewHelperImage($this->arguments['src'], $this->arguments['image'], $this->arguments['treatIdAsReference']);
             if ($this->arguments['realCrop'] && $internalImage instanceof FileInterface) {
-                $src = $service->getCroppedImageSrcByFile($internalImage, $this->arguments['ratio']);
-                $treatIdAsReference = false;
+                $this->arguments['src'] = $service->getCroppedImageSrcByFile($internalImage, $this->arguments['ratio']);
+                $this->arguments['treatIdAsReference'] = false;
                 $image = null;
             }
         } catch (\Exception $ex) {


### PR DESCRIPTION
When using realCrop in ImageViewHelper a new src-argument is built but doesn't progagate to parent::render()-method anymore after afcd51 as parameters in call to parent::render() were removed from call