### PR TITLE
Fix the wizard inside of and irre element

### DIFF
--- a/Classes/Hooks/InlineRecord.php
+++ b/Classes/Hooks/InlineRecord.php
@@ -99,8 +99,8 @@ class InlineRecord implements InlineElementHookInterface
             // The arguments array is different in case this is called by an AJAX request
             // via an IRRE inside an IRRE...
             if (!isset($arguments['edit'])) {
-                $stuff = parse_url(GeneralUtility::getIndpEnv('HTTP_REFERER'));
-                parse_str($stuff['query'], $arguments);
+                $url = parse_url(GeneralUtility::getIndpEnv('HTTP_REFERER'));
+                parse_str($url['query'], $arguments);
             }
             $returnUrl = [
                 'edit' => $arguments['edit'],

--- a/Classes/Hooks/InlineRecord.php
+++ b/Classes/Hooks/InlineRecord.php
@@ -94,8 +94,14 @@ class InlineRecord implements InlineElementHookInterface
         $table = $childRecord['tablenames'];
         $uid = $parentUid;
 
-        $arguments = GeneralUtility::_GET();
-        if ($this->isValidRecord($table, $uid) && isset($arguments['edit'])) {
+        if ($this->isValidRecord($table, $uid)) {
+            $arguments = GeneralUtility::_GET();
+            // The arguments array is different in case this is called by an AJAX request
+            // via an IRRE inside an IRRE...
+            if (!isset($arguments['edit'])) {
+                $stuff = parse_url(GeneralUtility::getIndpEnv('HTTP_REFERER'));
+                parse_str($stuff['query'], $arguments);
+            }
             $returnUrl = [
                 'edit' => $arguments['edit'],
                 'returnUrl' => $arguments['returnUrl'],


### PR DESCRIPTION
We use the referer as a fallback if the wizard should be called from
inside an IRRE element, because the AJAX request lacks some of the
information we need to get back to the element.