### PR TITLE
Return file reference instead of file in FocusCropService

### DIFF
--- a/Classes/Service/FocusCropService.php
+++ b/Classes/Service/FocusCropService.php
@@ -63,7 +63,7 @@ class FocusCropService extends AbstractService
         }
         $image = $resourceFactory->getFileReferenceObject($src);
 
-        return $image->getOriginalFile();
+        return $image;
     }
 
     /**


### PR DESCRIPTION
Return file reference instead of file in FocusCropService, as using file makes it impossible to use the same image with different focuspoints (tested on Typo3 8.7)