### PR TITLE
allow focuspoints on FileReference to be null, so that MetaData values can be loaded

### DIFF
--- a/Classes/Domain/Model/FileReference.php
+++ b/Classes/Domain/Model/FileReference.php
@@ -16,7 +16,7 @@ class FileReference extends AbstractModel
      * Focus point Y.
      *
      * @var int
-     * @db
+     * @db int(11) null
      */
     protected $focusPointY;
 
@@ -24,7 +24,7 @@ class FileReference extends AbstractModel
      * Focus point X.
      *
      * @var int
-     * @db
+     * @db int(11) null
      */
     protected $focusPointX;
 


### PR DESCRIPTION
Accompanying PullRequest for my suggested fix in [Issue 60](https://github.com/lochmueller/focuspoint/issues/40#issuecomment-415080815)