### PR TITLE
fix imageFunctionConfiguration for TYPO3 9

### DIFF
--- a/Classes/Service/CropService.php
+++ b/Classes/Service/CropService.php
@@ -11,8 +11,10 @@ use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Frontend\Imaging\GifBuilder;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Crop images.
@@ -64,7 +66,11 @@ class CropService extends AbstractService
             'GifBuilder',
             'ImageMagick',
         ];
-        $configuration = isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['focuspoint']) ? \unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['focuspoint']) : [];
+        if(VersionNumberUtility::convertVersionStringToArray(VersionNumberUtility::getCurrentTypo3Version())['version_main'] < 9) {
+			$configuration = isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['focuspoint']) ? \unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['focuspoint']) : [];
+		} else {
+			$configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('focuspoint');
+		}
         $functionConfiguration = $configuration['imageFunctionConfiguration'] ?? 'png:cropViaGifBuilder;*:GraphicalFunctions';
         $parts = GeneralUtility::trimExplode(';', $functionConfiguration, true);
         foreach ($parts as $part) {


### PR DESCRIPTION
In TYPO3 9 the method to retrieve the Extension Configuration via unserialize has been marked as deprecated (in my case it didn't work at all anymore). There is a new API method to get the configuration, which should be used if possible.
see:
https://docs.typo3.org/typo3cms/CoreApiReference/ExtensionArchitecture/ConfigurationOptions/Index.html
https://docs.typo3.org/typo3cms/extensions/core/Changelog/9.0/Deprecation-82254-DeprecateGLOBALSTYPO3_CONF_VARSEXTextConf.html