### PR TITLE
Check if the palettes key exists before accessing

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -153,7 +153,7 @@ $GLOBALS['TCA']['tt_content'] = ArrayUtility::mergeRecursiveDistinct(
 // Check for v11
 $checkPalettes = ['image_settings', 'mediaAdjustments'];
 foreach ($checkPalettes as $p) {
-    if (\is_array($GLOBALS['TCA']['tt_content']['palettes'][$p])) {
+    if (isset($GLOBALS['TCA']['tt_content']['palettes'][$p]) && \is_array($GLOBALS['TCA']['tt_content']['palettes'][$p])) {
         $GLOBALS['TCA']['tt_content']['palettes'][$p]['showitem'] = str_replace(
             'imageborder;',
             'image_ratio,imageborder;',


### PR DESCRIPTION
We ran into an issue where `$GLOBALS['TCA']['tt_content']['palettes'][$p]` was not defined. Which resulted in an undefined key error.

With this code this error could be prevented.