### PR TITLE
CropService-Bugfix for TYPO3v12

### DIFF
--- a/Classes/Service/CropService.php
+++ b/Classes/Service/CropService.php
@@ -100,6 +100,11 @@ class CropService extends AbstractService
         int $sourceY,
         string $absoluteTempImageName
     ): void {
+
+        // early exit if absoluteTempImage exists
+        if (file_exists($absoluteTempImageName)) {
+            return;
+        }
         $size = getimagesize($absoluteImageName);
         $relativeImagePath = rtrim(PathUtility::getRelativePath(
             GeneralUtility::getIndpEnv('TYPO3_DOCUMENT_ROOT'),
@@ -133,7 +138,7 @@ class CropService extends AbstractService
         $imageResource = $gifBuilder->gifBuild();
         if ($imageResource !== null) {
             $processedFile = $imageResource->getPublicUrl();
-            if ($processedFile && !file_exists($absoluteTempImageName)) {
+            if ($processedFile) {
                 copy(Environment::getPublicPath() . '/' . $processedFile, $absoluteTempImageName);
             }
         }


### PR DESCRIPTION
The return value type of GifBuilder:gifBuild() has changed in TYPO3v13. 

See [gifBuild in v12](https://api.typo3.org/12.4/classes/TYPO3-CMS-Frontend-Imaging-GifBuilder.html#method_gifBuild) and [gifBuild in v13](https://api.typo3.org/13.4/classes/TYPO3-CMS-Frontend-Imaging-GifBuilder.html#method_gifBuild)

This patch makes the CropService in TYPO3v12 functional again by evaluating the TYPO3-Version and process the result accordingly.

Additionally a small performance tweak was introduced: as the generated image only gets written if it doesn't already exists there is no need to calculate it when not needed.
