### PR TITLE
Fix gifBuild path handling in CropService for TYP03 v13 compatibility

### DIFF
--- a/Classes/Service/CropService.php
+++ b/Classes/Service/CropService.php
@@ -142,17 +142,17 @@ class CropService extends AbstractService
         if ($versionService->getMajorVersion() < 13) {
             // TYPO3 prior v13 returns a string
             // see https://api.typo3.org/12.4/classes/TYPO3-CMS-Frontend-Imaging-GifBuilder.html#method_gifBuild
-            $processedFile = $gifBuilder->gifBuild();
+            $processedFile = Environment::getPublicPath() . '/' . $gifBuilder->gifBuild();
         } else {
             // TYPO3 from v13 up returns an imageResource
             // https://api.typo3.org/13.4/classes/TYPO3-CMS-Frontend-Imaging-GifBuilder.html#method_gifBuild
             $imageResource = $gifBuilder->gifBuild();
             if ($imageResource !== null) {
-                $processedFile = $imageResource->getPublicUrl();
+                $processedFile = $imageResource->getFullPath();
             }
         }
         if ($processedFile) {
-            copy(Environment::getPublicPath() . '/' . $processedFile, $absoluteTempImageName);
+            copy($processedFile, $absoluteTempImageName);
         }
     }
 


### PR DESCRIPTION
This patch fixes the path-resolution logic in `CropService::gifBuild()` so that it continues to work correctly when the TYP03 `public/` or `typo3temp/` folder is a symlink. 
Previously, under 13+ we were using getPublicUrl(), which breaks if your public directory isn't physically located at DOCUMENT_ROOT/public.

When your TYPO3 "public" directory or "typo3temp" directory is implemented as a symlink (certain deployment setups like deployer), getPublicUrl() may point to the wrong location and cause image processing to fail. 

See the original Forge ticket for details:
> https://forge.typo3.org/issues/106002